### PR TITLE
Fix 4.18 conflicts by revert

### DIFF
--- a/uksm-4.18.patch
+++ b/uksm-4.18.patch
@@ -1,18 +1,16 @@
 diff --git a/Documentation/vm/00-INDEX b/Documentation/vm/00-INDEX
-index f4a4f3e884cf..dc230da92410 100644
+index f4a4f3e884cf..7cd67029f735 100644
 --- a/Documentation/vm/00-INDEX
 +++ b/Documentation/vm/00-INDEX
-@@ -18,7 +18,9 @@ hwpoison.rst
+@@ -18,6 +18,8 @@ hwpoison.rst
  	- explains what hwpoison is
  ksm.rst
  	- how to use the Kernel Samepage Merging feature.
--mmu_notifier.rst
 +uksm.txt
 +	- Introduction to Ultra KSM
-+mmu_notifier.txt
+ mmu_notifier.rst
  	- a note about clearing pte/pmd and mmu notifications
  numa.rst
- 	- information about NUMA specific code in the Linux vm.
 diff --git a/Documentation/vm/uksm.txt b/Documentation/vm/uksm.txt
 new file mode 100644
 index 000000000000..be19a3127001
@@ -116,7 +114,7 @@ index 2fb04846ed11..a5eb30d5af6f 100644
  	show_val_kb(m, "Quicklists:     ", quicklist_total_size());
  #endif
 diff --git a/include/asm-generic/pgtable.h b/include/asm-generic/pgtable.h
-index 26ca0276b503..df9abc384fc1 100644
+index f59639afaa39..08d89ced1992 100644
 --- a/include/asm-generic/pgtable.h
 +++ b/include/asm-generic/pgtable.h
 @@ -817,12 +817,25 @@ extern void untrack_pfn(struct vm_area_struct *vma, unsigned long pfn,
@@ -156,32 +154,36 @@ index 26ca0276b503..df9abc384fc1 100644
  
  static inline unsigned long my_zero_pfn(unsigned long addr)
 diff --git a/include/linux/ksm.h b/include/linux/ksm.h
-index 161e8164abcf..6ede707acd2d 100644
+index 161e8164abcf..f0dbdf3c986a 100644
 --- a/include/linux/ksm.h
 +++ b/include/linux/ksm.h
-@@ -21,21 +21,6 @@ struct mem_cgroup;
+@@ -21,20 +21,16 @@ struct mem_cgroup;
  #ifdef CONFIG_KSM
  int ksm_madvise(struct vm_area_struct *vma, unsigned long start,
  		unsigned long end, int advice, unsigned long *vm_flags);
 -int __ksm_enter(struct mm_struct *mm);
 -void __ksm_exit(struct mm_struct *mm);
--
+ 
 -static inline int ksm_fork(struct mm_struct *mm, struct mm_struct *oldmm)
--{
++static inline struct stable_node *page_stable_node(struct page *page)
+ {
 -	if (test_bit(MMF_VM_MERGEABLE, &oldmm->flags))
 -		return __ksm_enter(mm);
 -	return 0;
--}
--
++	return PageKsm(page) ? page_rmapping(page) : NULL;
+ }
+ 
 -static inline void ksm_exit(struct mm_struct *mm)
--{
++static inline void set_page_stable_node(struct page *page,
++					struct stable_node *stable_node)
+ {
 -	if (test_bit(MMF_VM_MERGEABLE, &mm->flags))
 -		__ksm_exit(mm);
--}
++	page->mapping = (void *)((unsigned long)stable_node | PAGE_MAPPING_KSM);
+ }
  
  /*
-  * When do_swap_page() first faults in from swap what used to be a KSM page,
-@@ -54,6 +39,46 @@ struct page *ksm_might_need_to_copy(struct page *page,
+@@ -54,6 +50,33 @@ struct page *ksm_might_need_to_copy(struct page *page,
  void rmap_walk_ksm(struct page *page, struct rmap_walk_control *rwc);
  void ksm_migrate_page(struct page *newpage, struct page *oldpage);
  
@@ -210,25 +212,12 @@ index 161e8164abcf..6ede707acd2d 100644
 +static inline void ksm_exit(struct mm_struct *mm)
 +{
 +}
-+
-+static inline void set_page_stable_node(struct page *page,
-+                                        struct stable_node *stable_node)
-+{
-+        page->mapping = (void *)((unsigned long)stable_node | PAGE_MAPPING_KSM);
-+}
-+
-+static inline struct stable_node *page_stable_node(struct page *page)
-+{
-+        return PageKsm(page) ? page_rmapping(page) : NULL;
-+}
-+
-+
 +#endif /* !CONFIG_UKSM */
 +
  #else  /* !CONFIG_KSM */
  
  static inline int ksm_fork(struct mm_struct *mm, struct mm_struct *oldmm)
-@@ -89,4 +114,6 @@ static inline void ksm_migrate_page(struct page *newpage, struct page *oldpage)
+@@ -89,4 +112,6 @@ static inline void ksm_migrate_page(struct page *newpage, struct page *oldpage)
  #endif /* CONFIG_MMU */
  #endif /* !CONFIG_KSM */
  
@@ -1069,8 +1058,30 @@ index 8716bdabe1e6..3b47677abd1a 100644
  obj-$(CONFIG_PAGE_POISONING) += page_poison.o
  obj-$(CONFIG_SLAB) += slab.o
  obj-$(CONFIG_SLUB) += slub.o
+diff --git a/mm/ksm.c b/mm/ksm.c
+index a6d43cf9a982..60dad9a9ff1e 100644
+--- a/mm/ksm.c
++++ b/mm/ksm.c
+@@ -842,17 +842,6 @@ static int unmerge_ksm_pages(struct vm_area_struct *vma,
+ 	return err;
+ }
+ 
+-static inline struct stable_node *page_stable_node(struct page *page)
+-{
+-	return PageKsm(page) ? page_rmapping(page) : NULL;
+-}
+-
+-static inline void set_page_stable_node(struct page *page,
+-					struct stable_node *stable_node)
+-{
+-	page->mapping = (void *)((unsigned long)stable_node | PAGE_MAPPING_KSM);
+-}
+-
+ #ifdef CONFIG_SYSFS
+ /*
+  * Only called through the sysfs control interface:
 diff --git a/mm/memory.c b/mm/memory.c
-index 0e356dd923c2..5aff0bf15b14 100644
+index c5e87a3a82ba..164609219d0d 100644
 --- a/mm/memory.c
 +++ b/mm/memory.c
 @@ -128,6 +128,25 @@ EXPORT_SYMBOL(zero_pfn);
@@ -1138,7 +1149,7 @@ index 0e356dd923c2..5aff0bf15b14 100644
  
  			if (!PageAnon(page)) {
  				if (pte_dirty(ptent)) {
-@@ -2360,8 +2387,10 @@ static inline void cow_user_page(struct page *dst, struct page *src, unsigned lo
+@@ -2343,8 +2370,10 @@ static inline void cow_user_page(struct page *dst, struct page *src, unsigned lo
  			clear_page(kaddr);
  		kunmap_atomic(kaddr);
  		flush_dcache_page(dst);
@@ -1150,7 +1161,7 @@ index 0e356dd923c2..5aff0bf15b14 100644
  }
  
  static gfp_t __get_fault_gfp_mask(struct vm_area_struct *vma)
-@@ -2510,6 +2539,7 @@ static int wp_page_copy(struct vm_fault *vmf)
+@@ -2493,6 +2522,7 @@ static int wp_page_copy(struct vm_fault *vmf)
  							      vmf->address);
  		if (!new_page)
  			goto oom;
@@ -1158,7 +1169,7 @@ index 0e356dd923c2..5aff0bf15b14 100644
  	} else {
  		new_page = alloc_page_vma(GFP_HIGHUSER_MOVABLE, vma,
  				vmf->address);
-@@ -2536,7 +2566,9 @@ static int wp_page_copy(struct vm_fault *vmf)
+@@ -2519,7 +2549,9 @@ static int wp_page_copy(struct vm_fault *vmf)
  						mm_counter_file(old_page));
  				inc_mm_counter_fast(mm, MM_ANONPAGES);
  			}
@@ -6948,6 +6959,3 @@ index 8ba0870ecddd..b977e00d9636 100644
  	/* enum writeback_stat_item counters */
  	"nr_dirty_threshold",
  	"nr_dirty_background_threshold",
--- 
-2.18.0
-


### PR DESCRIPTION
This reverts 88484826bc67844eeae1855ebe32cce9edd937c9 before applying
the uksm patch so we do not duplicate kernel functions which may lead to
missing changes in the future.

It also fixes a simple rebase error in vm/00-INDEX:

```diff
 diff --git a/Documentation/vm/00-INDEX b/Documentation/vm/00-INDEX
-index f4a4f3e884cf..dc230da92410 100644
+index f4a4f3e884cf..7cd67029f735 100644
 --- a/Documentation/vm/00-INDEX
 +++ b/Documentation/vm/00-INDEX
-@@ -18,7 +18,9 @@ hwpoison.rst
+@@ -18,6 +18,8 @@ hwpoison.rst
        - explains what hwpoison is
  ksm.rst
        - how to use the Kernel Samepage Merging feature.
--mmu_notifier.rst
 +uksm.txt
 +      - Introduction to Ultra KSM
-+mmu_notifier.txt
+ mmu_notifier.rst
        - a note about clearing pte/pmd and mmu notifications
  numa.rst
-       - information about NUMA specific code in the Linux vm.
```

Signed-off-by: Kai Krakow <kai@kaishome.de>